### PR TITLE
Drop dateutil. Use xbmc.getRegion and time.strptime

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,6 @@
 <addon id="service.kn.switchtimer" name="KN Switchtimer Service" provider-name="Birger Jesch" version="2.0.8">
     <requires>
         <import addon="xbmc.python" version="2.24.0"/>
-        <import addon="script.module.dateutil" version="2.5.3"/>
         <import addon="xbmc.json" version="6.20.0"/>
     </requires>
     <extension point="xbmc.service" library="service.py" start="login" />

--- a/handler.py
+++ b/handler.py
@@ -3,7 +3,6 @@
 
 import sys
 import time
-from dateutil import parser
 import xbmc, xbmcaddon, xbmcgui
 import os
 import operator
@@ -58,9 +57,11 @@ def notifyLog(message, level=xbmc.LOGDEBUG):
 def notifyOSD(header, message, icon=IconDefault, time=5000):
     OSD.notification(header.encode('utf-8'), message.encode('utf-8'), icon, time)
 
-def date2timeStamp(pdate, dayfirst=True):
-    df=xbmc.getRegion('dateshort')
-    dtt = parser.parse(pdate, fuzzy=True, dayfirst=dayfirst).timetuple()
+def date2timeStamp(pdate):
+    # Kodi bug: returns '%H%H' or '%I%I'
+    df=xbmc.getRegion('dateshort') + ' ' + xbmc.getRegion('time').replace('%H%H','%H').replace('%I%I','%I').replace(':%S','')
+    notifyLog(pdate + ' ' + df)
+    dtt = time.strptime(pdate, df)
     return int(time.mktime(dtt))
 
 def setTimer(params):
@@ -69,12 +70,9 @@ def setTimer(params):
 
     _now = int(time.time())
     if _now > utime:
-        notifyLog('Timer date possibly in the past, trying another date format', xbmc.LOGNOTICE)
-        utime =date2timeStamp(params['date'], dayfirst=False)
-        if _now > utime:
-            notifyLog('Timer date in the past or couldn\'t determine date format', xbmc.LOGNOTICE)
-            notifyOSD(__LS__(30000), __LS__(30022), icon=IconAlert)
-            return False
+        notifyLog('Timer date in the past', xbmc.LOGNOTICE)
+        notifyOSD(__LS__(30000), __LS__(30022), icon=IconAlert)
+        return False
 
     timers = getTimer()
     for timer in timers:


### PR DESCRIPTION
Motivation of this PR is that dateutil does not support my favorite YYYY-MM-DD short date format.

Successfully tested some combinations of common and exotic date and time formats.

The solution needs to work around a kodi bug in xbmc.getRegion('time').